### PR TITLE
feat: add dark theme support

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -90,13 +90,12 @@ export default function RootLayout({
         )}
       </head>
       <body
-        className={`${inter.variable} ${jetbrainsMono.variable} font-sans antialiased min-h-screen`}
+        className={`${inter.variable} ${jetbrainsMono.variable} font-sans antialiased min-h-screen bg-background text-foreground`}
       >
         <ThemeProvider
           attribute="class"
-          defaultTheme="light"
-          enableSystem={false}
-          forcedTheme="light"
+          defaultTheme="system"
+          enableSystem
           disableTransitionOnChange
         >
           {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,7 +34,7 @@ export default function Home() {
     <>
       <StructuredData data={homePageStructuredData} />
       <StructuredData data={organizationStructuredData} />
-      <div className="min-h-screen bg-white flex flex-col">
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 flex flex-col">
         {/* Header */}
         <HeaderServer />
       
@@ -43,10 +43,10 @@ export default function Home() {
           <div className="max-w-7xl mx-auto">
             {/* Hero Section */}
             <div className="text-center mb-12">
-              <h1 className="text-xl md:text-4xl font-bold text-slate-900 mb-6">
+              <h1 className="text-xl md:text-4xl font-bold text-slate-900 dark:text-slate-100 mb-6">
                 Every tool you need to work with JSONs in one place
               </h1>
-              <p className="text-lg text-slate-600 mb-8 max-w-4xl mx-auto leading-relaxed">
+              <p className="text-lg text-slate-600 dark:text-slate-300 mb-8 max-w-4xl mx-auto leading-relaxed">
                 Every tool you need to use JSONs, at your fingertips. All are 100% FREE and easy to use! Format, validate, convert, compare and generate JSONs with just a few clicks.
               </p>
             </div>

--- a/src/app/validator/page.tsx
+++ b/src/app/validator/page.tsx
@@ -24,7 +24,7 @@ import { ImportJsonDialog } from "@/components/import/ImportJsonDialog";
 import { useClipboard } from "@/hooks/useClipboard";
 
 export default function ValidatorPage() {
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
   const { copy } = useClipboard();
   const [inputJson, setInputJson] = useState('');
   const [showImportDialog, setShowImportDialog] = useState(false);
@@ -157,7 +157,7 @@ export default function ValidatorPage() {
                     language="json"
                     value={inputJson}
                     onChange={(value) => handleInputChange(value || '')}
-                    theme={theme === 'dark' ? 'vs-dark' : 'vs'}
+                    theme={resolvedTheme === 'dark' ? 'vs-dark' : 'vs'}
                     options={{
                       minimap: { enabled: false },
                       fontSize: 14,

--- a/src/components/home/FeatureCards.tsx
+++ b/src/components/home/FeatureCards.tsx
@@ -29,6 +29,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
+import { cn } from "@/lib/utils";
 
 interface FeatureCard {
   id: string;
@@ -156,6 +157,20 @@ const schemaFeatures: FeatureCard[] = [
   }
 ];
 
+const colorStyles: Record<string, { background: string; icon: string }> = {
+  blue: { background: "bg-blue-100 dark:bg-blue-900/30", icon: "text-blue-600 dark:text-blue-300" },
+  green: { background: "bg-green-100 dark:bg-green-900/30", icon: "text-green-600 dark:text-green-300" },
+  purple: { background: "bg-purple-100 dark:bg-purple-900/30", icon: "text-purple-600 dark:text-purple-300" },
+  orange: { background: "bg-orange-100 dark:bg-orange-900/30", icon: "text-orange-600 dark:text-orange-300" },
+  cyan: { background: "bg-cyan-100 dark:bg-cyan-900/30", icon: "text-cyan-600 dark:text-cyan-300" },
+  red: { background: "bg-red-100 dark:bg-red-900/30", icon: "text-red-600 dark:text-red-300" },
+  emerald: { background: "bg-emerald-100 dark:bg-emerald-900/30", icon: "text-emerald-600 dark:text-emerald-300" },
+  indigo: { background: "bg-indigo-100 dark:bg-indigo-900/30", icon: "text-indigo-600 dark:text-indigo-300" },
+  amber: { background: "bg-amber-100 dark:bg-amber-900/30", icon: "text-amber-600 dark:text-amber-300" },
+  yellow: { background: "bg-yellow-100 dark:bg-yellow-900/30", icon: "text-yellow-600 dark:text-yellow-300" },
+  default: { background: "bg-gray-100 dark:bg-slate-800/80", icon: "text-gray-600 dark:text-slate-300" },
+};
+
 export function FeatureCards() {
   const [activeCategory, setActiveCategory] = useState('all');
   
@@ -199,7 +214,7 @@ export function FeatureCards() {
     <div className="space-y-8">
       {/* Category Tabs */}
       <div className="flex flex-wrap justify-center gap-2 mb-8">
-        {[
+        {[ 
           { id: 'all', label: 'All', count: allTools.length },
           { id: 'core', label: 'Core Tools', count: coreFeatures.length },
           { id: 'schema', label: 'JSON Schema', count: schemaFeatures.length },
@@ -209,11 +224,12 @@ export function FeatureCards() {
           <button
             key={category.id}
             onClick={() => setActiveCategory(category.id)}
-            className={`px-4 py-2 rounded-full text-sm font-medium transition-all duration-200 ${
+            className={cn(
+              "px-4 py-2 rounded-full text-sm font-medium transition-all duration-200",
               activeCategory === category.id
-                ? 'bg-blue-600 text-white shadow-md'
-                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-            }`}
+                ? "bg-blue-600 text-white shadow-md dark:bg-blue-500 dark:text-white dark:shadow-blue-900/30"
+                : "bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+            )}
           >
             {category.label}
           </button>
@@ -224,50 +240,31 @@ export function FeatureCards() {
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-5 2xl:grid-cols-5 gap-3">
         {filteredTools.map((tool) => {
           const IconComponent = tool.icon;
+          const styles = colorStyles[tool.color] ?? colorStyles.default;
           return (
             <Link
               key={tool.id}
               href={tool.href}
-              className="group bg-white rounded-lg border border-gray-200 p-4 text-center hover:shadow-lg transition-all duration-200 hover:border-blue-300"
+              className={cn(
+                "group rounded-lg border p-4 text-center transition-all duration-200",
+                "bg-white border-gray-200 hover:shadow-lg hover:border-blue-300",
+                "dark:bg-slate-900 dark:border-slate-700 dark:hover:border-blue-500 dark:hover:bg-slate-800"
+              )}
             >
-              <div className={`w-12 h-12 mx-auto mb-3 rounded-lg flex items-center justify-center ${
-                tool.color === 'blue' ? 'bg-blue-100' :
-                tool.color === 'green' ? 'bg-green-100' :
-                tool.color === 'purple' ? 'bg-purple-100' :
-                tool.color === 'orange' ? 'bg-orange-100' :
-                tool.color === 'cyan' ? 'bg-cyan-100' :
-                tool.color === 'red' ? 'bg-red-100' :
-                tool.color === 'emerald' ? 'bg-emerald-100' :
-                tool.color === 'indigo' ? 'bg-indigo-100' :
-                tool.color === 'amber' ? 'bg-amber-100' :
-                tool.color === 'yellow' ? 'bg-yellow-100' :
-                'bg-gray-100'
-              }`}>
-                <IconComponent className={`w-8 h-8 ${
-                  tool.color === 'blue' ? 'text-blue-600' :
-                  tool.color === 'green' ? 'text-green-600' :
-                  tool.color === 'purple' ? 'text-purple-600' :
-                  tool.color === 'orange' ? 'text-orange-600' :
-                  tool.color === 'cyan' ? 'text-cyan-600' :
-                  tool.color === 'red' ? 'text-red-600' :
-                  tool.color === 'emerald' ? 'text-emerald-600' :
-                  tool.color === 'indigo' ? 'text-indigo-600' :
-                  tool.color === 'amber' ? 'text-amber-600' :
-                  tool.color === 'yellow' ? 'text-yellow-600' :
-                  'text-gray-600'
-                }`} />
+              <div className={cn("w-12 h-12 mx-auto mb-3 rounded-lg flex items-center justify-center", styles.background)}>
+                <IconComponent className={cn("w-8 h-8", styles.icon)} />
               </div>
-              
-              <h3 className="font-semibold text-gray-900 mb-2 group-hover:text-blue-600 transition-colors text-sm">
+
+              <h3 className="font-semibold text-gray-900 dark:text-slate-100 mb-2 group-hover:text-blue-600 dark:group-hover:text-blue-300 transition-colors text-sm">
                 {tool.title}
               </h3>
-              <p className="text-xs text-gray-600 leading-relaxed">
+              <p className="text-xs text-gray-600 dark:text-slate-400 leading-relaxed">
                 {tool.description}
               </p>
-              
+
               {tool.badge && (
                 <div className="mt-3">
-                  <span className="inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full font-medium">
+                  <span className="inline-block bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-200 text-xs px-2 py-1 rounded-full font-medium">
                     {tool.badge}
                   </span>
                 </div>

--- a/src/components/layout/ConverterLayout.tsx
+++ b/src/components/layout/ConverterLayout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReactNode } from "react";
+import { useTheme } from "next-themes";
 import { Editor } from "@monaco-editor/react";
 import {
   Download,
@@ -108,6 +109,8 @@ export function ConverterLayout({
   extraActions,
   stats
 }: ConverterLayoutProps) {
+  const { resolvedTheme } = useTheme();
+
 
   const defaultEmptyState = (
     <div className="h-full flex items-center justify-center text-slate-500 dark:text-slate-400">
@@ -191,7 +194,7 @@ export function ConverterLayout({
                       defaultLanguage={inputLanguage}
                       value={inputData}
                       onChange={onInputChange}
-                      theme="vs"
+                      theme={resolvedTheme === "dark" ? "vs-dark" : "vs"}
                       options={{
                         minimap: { enabled: false },
                         fontSize: 14,
@@ -288,7 +291,7 @@ export function ConverterLayout({
                       height="100%"
                       defaultLanguage={outputLanguage}
                       value={outputData}
-                      theme="vs"
+                      theme={resolvedTheme === "dark" ? "vs-dark" : "vs"}
                       options={{
                         minimap: { enabled: false },
                         fontSize: 14,

--- a/src/components/layout/HeaderServer.tsx
+++ b/src/components/layout/HeaderServer.tsx
@@ -1,9 +1,6 @@
 import Link from "next/link";
-import { 
-  Sun, 
-  Moon, 
-  Settings, 
-  ChevronDown, 
+import {
+  ChevronDown,
   Edit3,
   ArrowRightLeft,
   Code2,
@@ -30,13 +27,14 @@ import {
   FileArchive,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { 
-  editorMenuItems, 
+import {
+  editorMenuItems,
   converterMenuSections, 
   generatorMenuSections, 
   schemaMenuItems 
 } from "@/data/navigation";
 import { DropdownMenu } from "@/components/ui/DropdownMenuServer";
+import { ThemeToggle } from "./ThemeToggle";
 
 // 图标映射
 const iconMap: Record<string, any> = {
@@ -223,18 +221,10 @@ export function HeaderServer({ currentPath = "" }: HeaderServerProps) {
 
            
           </div>
-           {/* Additional Actions */}
-           <div className="flex items-center space-x-2 border-slate-200 dark:border-slate-700 pl-4">
-              {/* Theme Toggle - Invisible but with placeholder */}
-              <div className="p-2 rounded-lg invisible">
-                <div className="w-5 h-5" />
-              </div>
-
-              {/* Settings - Invisible but with placeholder */}
-              <div className="p-2 rounded-lg invisible">
-                <div className="w-5 h-5" />
-              </div>
-            </div>
+          {/* Additional Actions */}
+          <div className="flex items-center space-x-2 pl-4 border-l border-slate-200 dark:border-slate-700">
+            <ThemeToggle className="text-slate-600 hover:text-slate-900 dark:text-slate-300 dark:hover:text-slate-100" />
+          </div>
         </div>
       </div>
     </header>

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface ThemeToggleProps {
+  className?: string;
+}
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const isDark = resolvedTheme === "dark";
+
+  const handleToggle = () => {
+    setTheme(isDark ? "light" : "dark");
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      onClick={handleToggle}
+      aria-label={`Switch to ${isDark ? "light" : "dark"} theme`}
+      aria-pressed={isDark}
+      className={cn("relative", className)}
+    >
+      <Sun
+        className={cn(
+          "h-5 w-5 transition-all",
+          mounted && isDark ? "rotate-90 scale-0" : "rotate-0 scale-100"
+        )}
+      />
+      <Moon
+        className={cn(
+          "absolute h-5 w-5 transition-all",
+          mounted && isDark ? "rotate-0 scale-100" : "-rotate-90 scale-0"
+        )}
+      />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- enable global theme provider to respect system preference and expose a reusable toggle in the header
- refresh homepage and feature listing styles so copy and cards adapt to the dark palette
- synchronize Monaco-based editors with the active theme across converter and validator experiences

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c980b02d6483309f7474a7007bfb68